### PR TITLE
Don't send teams when TAB is enabled. Closes #11.

### DIFF
--- a/src/main/java/me/itsskeptical/displaytags/utils/handlers/NametagHandler.java
+++ b/src/main/java/me/itsskeptical/displaytags/utils/handlers/NametagHandler.java
@@ -27,6 +27,7 @@ public class NametagHandler {
     }
 
     public static void hide(Player target, Player viewer) {
+        if (DependencyHelper.isTABEnabled()) return;
         String name = getTeamName(target);
         WrapperPlayServerTeams.ScoreBoardTeamInfo teamInfo = new WrapperPlayServerTeams.ScoreBoardTeamInfo(
                 Component.empty(),
@@ -47,6 +48,7 @@ public class NametagHandler {
     }
 
     public static void show(Player target, Player viewer) {
+        if (DependencyHelper.isTABEnabled()) return;
         String name = getTeamName(target);
         WrapperPlayServerTeams packet = new WrapperPlayServerTeams(
                 name,

--- a/src/main/java/me/itsskeptical/displaytags/utils/handlers/NametagHandler.java
+++ b/src/main/java/me/itsskeptical/displaytags/utils/handlers/NametagHandler.java
@@ -27,7 +27,7 @@ public class NametagHandler {
     }
 
     public static void hide(Player target, Player viewer) {
-        if (DependencyHelper.isTABEnabled()) return;
+        if (DependencyHelper.isTABEnabled() && TabAPI.getInstance().getNameTagManager() != null) return;
         String name = getTeamName(target);
         WrapperPlayServerTeams.ScoreBoardTeamInfo teamInfo = new WrapperPlayServerTeams.ScoreBoardTeamInfo(
                 Component.empty(),
@@ -48,7 +48,7 @@ public class NametagHandler {
     }
 
     public static void show(Player target, Player viewer) {
-        if (DependencyHelper.isTABEnabled()) return;
+        if (DependencyHelper.isTABEnabled() && TabAPI.getInstance().getNameTagManager() != null) return;
         String name = getTeamName(target);
         WrapperPlayServerTeams packet = new WrapperPlayServerTeams(
                 name,


### PR DESCRIPTION
Prevents DisplayTags' teams from overriding TAB's and therefore messing up sorting.