### PR TITLE
Fixed a missing null check error.

### DIFF
--- a/src/main/java/me/itsskeptical/displaytags/listeners/PlayerListener.java
+++ b/src/main/java/me/itsskeptical/displaytags/listeners/PlayerListener.java
@@ -40,7 +40,10 @@ public class PlayerListener implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
         if (plugin.config().getNametagConfig().isEnabled()) {
             Nametag nametag = nametagManager.get(event.getPlayer());
-            nametag.hideForAll();
+            // NULL CHECK
+            if (nametag != null) {
+                nametag.hideForAll();
+            }
         }
     }
 
@@ -48,7 +51,10 @@ public class PlayerListener implements Listener {
     public void onPlayerTeleport(PlayerTeleportEvent event) {
         if (plugin.config().getNametagConfig().isEnabled()) {
             Nametag nametag = nametagManager.get(event.getPlayer());
-            nametag.updateVisibilityForAll();
+            // NULL CHECK
+            if (nametag != null) {
+                nametag.updateVisibilityForAll();
+            }
         }
     }
 
@@ -56,8 +62,11 @@ public class PlayerListener implements Listener {
     public void onPlayerWorldChange(PlayerChangedWorldEvent event) {
         if (plugin.config().getNametagConfig().isEnabled()) {
             Nametag nametag = nametagManager.get(event.getPlayer());
-            nametag.hideForAll();
-            nametag.updateVisibilityForAll();
+            // NULL CHECK
+            if (nametag != null) {
+                nametag.hideForAll();
+                nametag.updateVisibilityForAll();
+            }
         }
     }
 


### PR DESCRIPTION
This error is returned due to a missing null check.

```java
java.lang.NullPointerException: Cannot invoke "me.itsskeptical.displaytags.nametags.Nametag.updateVisibilityForAll()" because "nametag" is null

at DisplayTags-1.1.3.jar/me.itsskeptical.displaytags.listeners.PlayerListener.onPlayerTeleport(PlayerListener.java:51) ~[DisplayTags-1.1.3.jar:?]

at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[pufferfish-api-1.21.10-R0.1-SNAPSHOT.jar:?]

at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[pufferfish-api-1.21.10-R0.1-SNAPSHOT.jar:?]

at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:630) ~[pufferfish-api-1.21.10-R0.1-SNAPSHOT.jar:?]

at net.minecraft.server.level.ServerPlayer.teleport(ServerPlayer.java:1500) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at net.minecraft.server.level.ServerPlayer.teleport(ServerPlayer.java:205) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.craftbukkit.entity.CraftEntity.teleport0(CraftEntity.java:312) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.craftbukkit.entity.CraftPlayer.teleport0(CraftPlayer.java:1317) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.craftbukkit.entity.CraftEntity.teleport(CraftEntity.java:296) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.craftbukkit.entity.CraftEntity.teleport(CraftEntity.java:286) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.craftbukkit.entity.CraftEntity.teleport(CraftEntity.java:281) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at PracticeCore-1.0-SNAPSHOT.jar/net.lunallite.practiceCore.Core.Essentials.Events.Join.SpawnJoin.lambda$onJoin$0(SpawnJoin.java:28) ~[PracticeCore-1.0-SNAPSHOT.jar:?]

at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1746) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1620) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:434) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1340) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:386) ~[pufferfish-1.21.10.jar:1.21.10-39-b98b265]

at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]

```