### PR TITLE
Fix typo: DisplaysTags → DisplayTags in enable log message

### DIFF
--- a/src/main/java/me/itsskeptical/displaytags/DisplayTags.java
+++ b/src/main/java/me/itsskeptical/displaytags/DisplayTags.java
@@ -51,7 +51,7 @@ public final class DisplayTags extends JavaPlugin {
         checkForUpdates(getServer().getConsoleSender());
 
         String version = getPluginMeta().getVersion();
-        getLogger().info(String.format("DisplaysTags v%s has been enabled.", version));
+        getLogger().info(String.format("DisplayTags v%s has been enabled.", version));
     }
 
     @Override


### PR DESCRIPTION
Fixed a spelling error in DisplayTags.java where the plugin name was logged as DisplaysTags (extra 's') instead of the correct DisplayTags.